### PR TITLE
Fix typo, and do not error when no QueryString is matched

### DIFF
--- a/modules/core/src/main/scala/net/findhotel/akka/stream/trace/Directives.scala
+++ b/modules/core/src/main/scala/net/findhotel/akka/stream/trace/Directives.scala
@@ -26,6 +26,7 @@ object Directives {
     }
     r.uri.rawQueryString match {
       case Some(qs) => scope.addKVAnnotation("query string", qs)
+      case None =>
     }
 
     scope
@@ -53,7 +54,7 @@ object Directives {
     val maybeTraceId = Try(req.getHeader(HTRACE_HEADER_NAME).get().value()).toOption
     val s = handleNewScope(req, maybeTraceId)
     val f = Route.asyncHandler(startScope(s) { route }).apply(req.withHeaders(createHtraceHeader(s)))
-    f.andThen { case _ => s.addTimelineAnnotation("Requset closed"); s.reattach(); s.close() }
+    f.andThen { case _ => s.addTimelineAnnotation("Request closed"); s.reattach(); s.close() }
     s.detach()
     f
   }


### PR DESCRIPTION
Small fix to handle case where query parameters are not passed (and fixes typo)